### PR TITLE
Fix: CheckerFramework version bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ configurations {
 
 ext {
     versions = [
-        checkerFramework: "3.42.0-eisop5",
+        checkerFramework: "3.49.3-eisop1",
         errorproneJavacVersion: "9+181-r4173-1",
         errorproneCoreVersion: "2.40.0",
     ]

--- a/crypto-checker-qual-android/build.gradle
+++ b/crypto-checker-qual-android/build.gradle
@@ -10,6 +10,9 @@ ext.versions = [
     checkerFramework: "3.42.0-eisop5",
 ]
 
+//def checkerframework_local = true  // Set this variable to [true] while using local version of checker framework.
+//def CHECKERFRAMEWORK = "/home/billybai/code/vehiloco/local_CF"
+
 dependencies {
     implementation "io.github.eisop:checker:${versions.checkerFramework}"
     implementation "io.github.eisop:checker-qual:${versions.checkerFramework}"

--- a/crypto-checker-qual/build.gradle
+++ b/crypto-checker-qual/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 ext.versions = [
-    checkerFramework: "3.42.0-eisop5",
+    checkerFramework: "3.49.3-eisop1",
 ]
 
 dependencies {

--- a/src/main/java/org/checkerframework/checker/crypto/CryptoChecker.java
+++ b/src/main/java/org/checkerframework/checker/crypto/CryptoChecker.java
@@ -2,6 +2,7 @@ package org.checkerframework.checker.crypto;
 
 import org.checkerframework.common.basetype.BaseTypeChecker;
 import org.checkerframework.common.value.ValueChecker;
+import org.checkerframework.framework.source.SourceChecker;
 import org.checkerframework.framework.source.SupportedLintOptions;
 
 import java.util.Set;
@@ -10,8 +11,8 @@ import java.util.Set;
 public class CryptoChecker extends BaseTypeChecker {
 
     @Override
-    protected Set<Class<? extends BaseTypeChecker>> getImmediateSubcheckerClasses() {
-        Set<Class<? extends BaseTypeChecker>> checkers = super.getImmediateSubcheckerClasses();
+    protected Set<Class<? extends SourceChecker>> getImmediateSubcheckerClasses() {
+        Set<Class<? extends SourceChecker>> checkers = super.getImmediateSubcheckerClasses();
         checkers.add(ValueChecker.class);
         return checkers;
     }

--- a/tests/general/GlbLubTest.java
+++ b/tests/general/GlbLubTest.java
@@ -64,7 +64,6 @@ class GlbLubTest {
     }
 
     void testGlb1() {
-        // ::error: (assignment.type.incompatible)
         MyClass1<? extends @AllowedAlgorithms({"a", "c", "e"}) String> f1 = new MyClass1<>();
         @AllowedAlgorithms({"a", "c"})
         String x = f1.key;
@@ -78,7 +77,6 @@ class GlbLubTest {
     }
 
     void testGlb2() {
-        // ::error: (assignment.type.incompatible)
         MyClass2<? extends @AllowedAlgorithms("a") String> f2 = new MyClass2<>();
         @AllowedAlgorithms({"e"})
         String x = f2.key;
@@ -89,7 +87,6 @@ class GlbLubTest {
     }
 
     void testGlb3() {
-        // ::error: (assignment.type.incompatible)
         MyClass3<? extends @AllowedAlgorithms("a") String> f3 = new MyClass3<>();
         @AllowedAlgorithms({"b"})
         String x = f3.key;


### PR DESCRIPTION
The CF version bump #349 fails at the test to compute the greatest lower bound and lowest upper bound. Consider the code snippet:

### Problem Description
``` java
class test<T extends @AllowedAlgorithms({"a", "b"}) String> {}

void m() {
        test<? extends @AllowedAlgorithms({"a", "c"}) String> f1 = new test<>();
}
```

Here the object creation should be valid if we compute the lub as `@AllowedAlgorithms({"a"}) String`. However, in the handling before 3.43.0 release is that it takes the upper bound at class decl directly, which is `@AllowedAlgorithms({"a", "b"}`. Hence, here was expected an `assignment.type.incompatible` error before. 

### Solution
By removing this type of error specifications, and adapt the change of CF APIs (some signatures changed from `BaseTypeChecker` to `SourceChecker`), the build succeed.